### PR TITLE
fix odd titlebar button behavior on linux

### DIFF
--- a/resources/misc.css
+++ b/resources/misc.css
@@ -1229,3 +1229,10 @@
 		}
 	}
 }
+
+/* Libadwaita circular titlebar buttons */
+@media (-moz-gtk-theme-family: adwaita) or (-moz-gtk-theme-family: yaru) {
+    .titlebar-button > .toolbarbutton-icon {
+        clip-path: circle(50%);
+    }
+}


### PR DESCRIPTION
simply applies a circle mask to the titlebar buttons on (lib)adwaita and yaru themes using a clip because border-radius appears not to work properly on 145

before:
<img width="403" height="222" alt="image" src="https://github.com/user-attachments/assets/3a7e3ee5-8400-4179-89c9-c7b12bdbc5ff" />

after:
<img width="403" height="222" alt="image" src="https://github.com/user-attachments/assets/d9e80b79-d959-41ef-811f-a750f6c681a8" />
